### PR TITLE
Add disable notify flag

### DIFF
--- a/NuGet.Services.Dashboard.Operations/ScriptsAndReferences/DeployDashboardTasks.ps1
+++ b/NuGet.Services.Dashboard.Operations/ScriptsAndReferences/DeployDashboardTasks.ps1
@@ -48,7 +48,7 @@ CreateTask "CreatePingdomHourlyReport" "cpdwr -user `"$PingdomUserName`" -passwo
 CreateTask "CreatePingdomServiceDisruptionReport" "psdrt -user `"$PingdomUserName`" -password `"$PingdomPassword`" -appkey `"$PingdomAppKey`" -n 1 -st `"$DashboardStorageConnectionString`" -ct $DashboardStorageContainerName" 60
 
 # SearchService tasks
-CreateTask "CreateConsolidatedSearchIndexingStatusReportTask" "ccsisrt -db `"$FrontEndLegacyDBConnectionString`" -se $ConsolidatedSearchServiceEndPoint -st `"$DashboardStorageConnectionString`" -ct $DashboardStorageContainerName -alsev1 120 -alsev2 30" 60
+CreateTask "CreateConsolidatedSearchIndexingStatusReportTask" "ccsisrt -db `"$FrontEndLegacyDBConnectionString`" -se $ConsolidatedSearchServiceEndPoint -st `"$DashboardStorageConnectionString`" -ct $DashboardStorageContainerName -alsev1 120 -alsev2 30 -disn -disic" 60
 
 # Misc
 CreateTask "CreateRequestsCountOverviewReport" "crphrt -iis `"$FrontEndStorageConnectionString`" -retry 3 -servicename $FrontEndCloudServiceName  -st `"$DashboardStorageConnectionString`" -ct $DashboardStorageContainerName" 60 

--- a/NuGet.Services.Dashboard.Operations/Tasks/DashBoardTasks/ConsolidatedSearch/CreateSearchIndexingStatusReportTask.cs
+++ b/NuGet.Services.Dashboard.Operations/Tasks/DashBoardTasks/ConsolidatedSearch/CreateSearchIndexingStatusReportTask.cs
@@ -43,7 +43,9 @@ namespace NuGetGallery.Operations.Tasks.DashBoardTasks.SearchServiceTasks.Consol
                     Details = string.Format("Delta between the packages between in database and Lucene index is {0}. Allowed Threshold lag : {1} packages", difference, thresholdValues.LuceneIndexLagAlertErrorThreshold),
                     AlertName = "Error: Alert for LuceneIndexLag",
                     Component = "SearchService",
-                    Level = "Error"
+                    Level = "Error",
+                    DisableIncidentCreation = DisableIncidentCreation,
+                    DisableNotification = DisableNotification
                 }.ExecuteCommand();
             }
             else if (difference > thresholdValues.LuceneIndexLagAlertWarningThreshold)
@@ -54,7 +56,9 @@ namespace NuGetGallery.Operations.Tasks.DashBoardTasks.SearchServiceTasks.Consol
                     Details = string.Format("Delta between the packages between in database and Lucene index is {0}. Warning Threshold lag : {1} packages", difference, thresholdValues.LuceneIndexLagAlertWarningThreshold),
                     AlertName = "Warning: Alert for LuceneIndexLag",
                     Component = "SearchService",
-                    Level = "Warning"
+                    Level = "Warning",
+                    DisableIncidentCreation = DisableIncidentCreation,
+                    DisableNotification = DisableNotification
                 }.ExecuteCommand();
             }
 
@@ -74,7 +78,9 @@ namespace NuGetGallery.Operations.Tasks.DashBoardTasks.SearchServiceTasks.Consol
                     AlertName = "Error: Alert for LuceneIndexLag",
                     Component = "SearchService",
                     Level = "Error",
-                    EscPolicy = "Sev1"
+                    EscPolicy = "Sev1",
+                    DisableIncidentCreation = DisableIncidentCreation,
+                    DisableNotification = DisableNotification
                 }.ExecuteCommand();
             }
             else if (indexLagInMinutes > AllowedLagInMinutesSev2)
@@ -85,7 +91,9 @@ namespace NuGetGallery.Operations.Tasks.DashBoardTasks.SearchServiceTasks.Consol
                     Details = string.Format("Search Index for endpoint {3} last updated {0} minutes back. Last activity (create/edit) in DB is at {1}, but Lucene is updated @ {2}", Math.Round(indexLagInMinutes, 2), lastActivityTime, luceneCommitTimeStamp, SearchEndPoint),
                     AlertName = "Warning: Alert for LuceneIndexLag",
                     Component = "SearchService",
-                    Level = "Error"
+                    Level = "Error",
+                    DisableIncidentCreation = DisableIncidentCreation,
+                    DisableNotification = DisableNotification
                 }.ExecuteCommand();
             }
 

--- a/NuGet.Services.Dashboard.Operations/Tasks/DashBoardTasks/ReportMailTasks/SendAlertMailTask.cs
+++ b/NuGet.Services.Dashboard.Operations/Tasks/DashBoardTasks/ReportMailTasks/SendAlertMailTask.cs
@@ -22,7 +22,7 @@ using System.Configuration;
 namespace NuGetGallery.Operations
 {
     [Command("SendAlertMailTask", "Creates a pager duty incident or sends an alert email based on configuration", AltName = "samt")]
-    public class SendAlertMailTask : OpsTask 
+    public class SendAlertMailTask : OpsTask
     {
         [Option("ErrorDetails", AltName = "e")]
         public string Details { get; set; }
@@ -32,7 +32,7 @@ namespace NuGetGallery.Operations
 
         [Option("AlertName", AltName = "n")]
         public string AlertName { get; set; }
-        
+
         [Option("Component", AltName = "c")]
         public string Component { get; set; }
 
@@ -45,13 +45,13 @@ namespace NuGetGallery.Operations
         public override void ExecuteCommand()
         {
             //Either create an incident or send mail based on the current settings.
-            if (ConfigurationManager.AppSettings["UsePagerDuty"].Equals("true", StringComparison.OrdinalIgnoreCase))
+            if (!DisableIncidentCreation && ConfigurationManager.AppSettings["UsePagerDuty"].Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 CreateIncident();  
             }
             else
             {
-                if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings["SmtpUserName"]) && !string.IsNullOrEmpty(ConfigurationManager.AppSettings["SmtpPassword"]))
+                if (!DisableNotification && !string.IsNullOrEmpty(ConfigurationManager.AppSettings["SmtpUserName"]) && !string.IsNullOrEmpty(ConfigurationManager.AppSettings["SmtpPassword"]))
                 {
                     SendEmail();
                 }

--- a/NuGet.Services.Dashboard.Operations/Tasks/OpsTask.cs
+++ b/NuGet.Services.Dashboard.Operations/Tasks/OpsTask.cs
@@ -52,6 +52,12 @@ namespace NuGetGallery.Operations
             }
         }
 
+        [Option("DisableNotification", AltName = "disn")]
+        public bool DisableNotification { get; set; }
+
+        [Option("DisableIncidentCreation", AltName = "disic")]
+        public bool DisableIncidentCreation { get; set; }
+
         [Option("Path to the configuration file to use when command line arguments aren't specified")]
         public string ConfigFile { get; set; }
 


### PR DESCRIPTION
Add a new flag to OpsTask to enable disabling incident creation and email alerts.
Currently only passed through for Search service task.

@joelverhagen @skofman1 @xavierdecoster @cristinamanum 